### PR TITLE
Fix __dirname fallback in configuration

### DIFF
--- a/src/node/halchemy/src/lib/configuration.ts
+++ b/src/node/halchemy/src/lib/configuration.ts
@@ -4,6 +4,11 @@ import * as fs from 'fs';
 import {readIniFileSync} from "read-ini-file";
 import { fileURLToPath } from "node:url";
 
+// Determine the directory of this module for both CJS and ESM environments
+const moduleDir = typeof __dirname !== 'undefined'
+    ? __dirname
+    : path.dirname(fileURLToPath(eval('import.meta.url')));
+
 
 function findProjectRoot(currentPath: string): string | undefined {
     // This function recursively searches for a directory containing `node_modules`
@@ -28,8 +33,7 @@ function findProjectRoot(currentPath: string): string | undefined {
 
 export function loadConfig(): any {
     const configFileName = '.halchemy';
-    const parentDir = (typeof __dirname !== 'undefined') ? __dirname : '.';
-    const projectRoot = findProjectRoot(parentDir);
+    const projectRoot = findProjectRoot(moduleDir);
     let config: any = {}
 
     if (projectRoot) {


### PR DESCRIPTION
## Summary
- compute current directory when `__dirname` is undefined
- use new helper when loading configuration

## Testing
- `npm run build`
- `npm test` *(fails: ERR_INVALID_URL)*

------
https://chatgpt.com/codex/tasks/task_e_686bf2ad5094832c8e5a04d5f074effb